### PR TITLE
Makefile: Add library version information

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -62,6 +62,8 @@ libpvrWAYLAND_WSEGL_la_LIBADD = \
 	$(WSEGL_CORE_LIBADD) \
 	-lsrv_um
 
+libpvrWAYLAND_WSEGL_la_LDFLAGS = -version-number $(PVRWAYLAND_WSEGL_SO_VERSION)
+
 noinst_HEADERS = \
 	src/waylandws.h \
 	src/waylandws_client.h \

--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,9 @@ AM_INIT_AUTOMAKE([foreign dist-bzip2 subdir-objects])
 # Initialize libtool
 AC_PROG_LIBTOOL
 
+# Add libtool library version information
+AC_SUBST([PVRWAYLAND_WSEGL_SO_VERSION], [3:1:1])
+
 # Check headers
 AC_CHECK_HEADERS([wayland-egl-backend.h])
 


### PR DESCRIPTION
Currently shared library generated is not versioned (libpvrWAYLAND_WSEGL.so.0.0.0). Add libtool library version information as we expect libpvrWAYLAND_WSEGL.so.3.1.1 to be generated as package version is 3.1.1.